### PR TITLE
Target tweaks

### DIFF
--- a/src/Framework/BizTalkDeploymentFramework.targets
+++ b/src/Framework/BizTalkDeploymentFramework.targets
@@ -2007,7 +2007,7 @@
     </GetBizTalkAppExists>
   </Target>
 
-  <Target Name="DeployBam" DependsOnTargets="ExportBAMXMLFromXLS;UndeployBam" Condition="'$(IncludeBAM)' == 'true'">
+  <Target Name="DeployBam" DependsOnTargets="UndeployBam" Condition="'$(IncludeBAM)' == 'true'">
     <!-- Deploy BAM definitions. -->
 
     <!-- First, deploy the BAM definitions -->
@@ -2052,7 +2052,7 @@
     <Message Text="Finished deploying BAM tracking profiles." Condition="'@(BamTrackingProfilesQualified)' != ''" />
   </Target>
 
-  <Target Name="UndeployBam" DependsOnTargets="ExportBAMXMLFromXLS" Condition="'$(IncludeBAM)' == 'true' and ('$(SkipUndeploy)' == 'false' and '$(SkipBamUndeploy)' == 'false')">
+  <Target Name="UndeployBam" DependsOnTargets="GetSoftwarePaths;InitializeAppName;ExportBAMXMLFromXLS" Condition="'$(IncludeBAM)' == 'true' and ('$(SkipUndeploy)' == 'false' and '$(SkipBamUndeploy)' == 'false')">
     <!-- Undeploy BAM definitions. -->
 
     <Message Text="Undeploying BAM tracking profiles..." Condition="'@(BamTrackingProfilesQualified)' != ''" />

--- a/src/Framework/BizTalkDeploymentFramework.targets
+++ b/src/Framework/BizTalkDeploymentFramework.targets
@@ -1192,7 +1192,7 @@
     <!-- Since host instance processes will be hanging on to DLLs... -->
   </Target>
 
-  <Target Name="BounceBizTalk" DependsOnTargets="SetWinVer">
+  <Target Name="BounceBizTalk" DependsOnTargets="GetSoftwarePaths">
     <!-- Reset BizTalk hosts and IIS -->
 
     <!-- An iisreset is needed with http & the isolated host, since your binaries will be loaded into IIS proceses. -->


### PR DESCRIPTION
Updated BAM dependant targets to allow (Un)DeployBAM targets to be called as single targets.
Fixed bug where using "BounceBizTalk" target (such as through VS extension) cannot find appcmd for iis app pools