### PR TITLE
Update MSBuild tasks reference to Microsoft.Build.Utilities.v4.0

### DIFF
--- a/src/Tools/BuildTasks/BizTalkDeploymentFramework.Tasks.BizTalk/BizTalkDeploymentFramework.Tasks.BizTalk.csproj
+++ b/src/Tools/BuildTasks/BizTalkDeploymentFramework.Tasks.BizTalk/BizTalkDeploymentFramework.Tasks.BizTalk.csproj
@@ -42,7 +42,7 @@
       <HintPath>..\..\..\..\..\Program Files\Microsoft BizTalk Server 2006\Microsoft.BizTalk.Operations.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.XLANGs.BizTalk.CrossProcess, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\Program Files\Microsoft BizTalk Server 2006\Microsoft.XLANGs.BizTalk.CrossProcess.dll</HintPath>

--- a/src/Tools/BuildTasks/BizTalkDeploymentFramework.Tasks.IIS/BizTalkDeploymentFramework.Tasks.IIS.csproj
+++ b/src/Tools/BuildTasks/BizTalkDeploymentFramework.Tasks.IIS/BizTalkDeploymentFramework.Tasks.IIS.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Administration.7.0.0.0\lib\net20\Microsoft.Web.Administration.dll</HintPath>
       <Private>True</Private>

--- a/src/Tools/BuildTasks/BizTalkDeploymentFramework.Tasks/BizTalkDeploymentFramework.Tasks.csproj
+++ b/src/Tools/BuildTasks/BizTalkDeploymentFramework.Tasks/BizTalkDeploymentFramework.Tasks.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.DirectoryServices" />


### PR DESCRIPTION
Update obsolete MSBuild tasks reference to Microsoft.Build.Utilities.v4.0.

Resolves #470